### PR TITLE
Remove use of for ... in loop on client_states iteration.

### DIFF
--- a/dist/oauth.js
+++ b/dist/oauth.js
@@ -716,7 +716,7 @@ module.exports = function($, config, client_states, cache, providers_api) {
         }
       }
       data.state = data.state.replace(/\s+/g, "");
-      for (k in client_states) {
+      for (var k=0; k < client_states.length; k++) {
         v = client_states[k];
         client_states[k] = v.replace(/\s+/g, "");
       }


### PR DESCRIPTION
The reason behind this is that EmberJS adds some sugar onto Arrays
and as a result, it's painful to iterate over arrays using the
for .. in style. I wish this wasn't the case, but I have to do this
in order to use the SDK with EmberJS.