### PR TITLE
fix(me-params): do not put filter param if no filter is passed

### DIFF
--- a/coffee/lib/oauthio_requests.coffee
+++ b/coffee/lib/oauthio_requests.coffee
@@ -197,7 +197,8 @@ module.exports = ($, config, client_states, cache, providers_api) ->
 				request: request
 
 			options.data = options.data or {}
-			options.data.filter = (if filter then filter.join(",") else `undefined`)
+			if filter
+				options.data.filter = filter.join(",")
 			base.http_me options
 
 	mkHttpAll: (provider, tokens, endpoint_descriptor) ->

--- a/dist/oauth.js
+++ b/dist/oauth.js
@@ -689,7 +689,9 @@ module.exports = function($, config, client_states, cache, providers_api) {
           request: request
         };
         options.data = options.data || {};
-        options.data.filter = (filter ? filter.join(",") : undefined);
+        if (filter) {
+          options.data.filter = filter.join(",");
+        }
         return base.http_me(options);
       };
     },


### PR DESCRIPTION
When using Zepto, $.param({filter:undefined}) returns "filter=undefined". So I only add `filter` to `data` if filter is truthy.